### PR TITLE
#26 added spanish annotations to work in default configuration

### DIFF
--- a/core/src/main/java/com/github/rodionmoiseev/c10n/annotations/DefaultC10NAnnotations.java
+++ b/core/src/main/java/com/github/rodionmoiseev/c10n/annotations/DefaultC10NAnnotations.java
@@ -42,6 +42,7 @@ public class DefaultC10NAnnotations extends C10NConfigBase {
     @Override
     protected void configure() {
         bindAnnotation(En.class).toLocale(Locale.ENGLISH);
+        bindAnnotation(Es.class).toLocale(new Locale("es"));
         bindAnnotation(De.class).toLocale(Locale.GERMAN);
         bindAnnotation(Fr.class).toLocale(Locale.FRENCH);
         bindAnnotation(It.class).toLocale(Locale.ITALIAN);

--- a/core/src/main/java/com/github/rodionmoiseev/c10n/annotations/Es.java
+++ b/core/src/main/java/com/github/rodionmoiseev/c10n/annotations/Es.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.github.rodionmoiseev.c10n.annotations;
+
+import com.github.rodionmoiseev.c10n.share.Constants;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotation bound to {@link java.util.Locale#SPANISH} locale
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Es {
+    String value() default Constants.UNDEF;
+
+    String extRes() default Constants.UNDEF;
+
+    String intRes() default Constants.UNDEF;
+
+    boolean raw() default false;
+}


### PR DESCRIPTION
I tested it with this file: https://gist.github.com/kevinrobayna/5e702ac5ada7424b3a90

Also i tried with 
```Java
C10N.configure(new C10NConfigBase() {
  @Override
  protected void configure() {
    bindAnnotation(Es.class); // also Ru and En
  }
});
```